### PR TITLE
add description to PacletInfo file

### DIFF
--- a/RhinoLink/PacletInfo.m
+++ b/RhinoLink/PacletInfo.m
@@ -5,14 +5,13 @@
 Paclet[
     Name -> "RhinoLink",
     Version -> "0.9.0",
+    Description -> "Wolfram Language interface to Rhino3D",
     MathematicaVersion -> "11+",
-    Extensions -> 
+    Extensions ->
         {
-            {"Documentation", Language -> "English", MainPage -> "Guides/RhinoLink"}, 
-            {"Kernel", Root -> "Kernel", Context -> 
+            {"Documentation", Language -> "English", MainPage -> "Guides/RhinoLink"},
+            {"Kernel", Root -> "Kernel", Context ->
                 {"RhinoLink`"}
             }
         }
 ]
-
-


### PR DESCRIPTION
paclet info descriptions show up in guide/InstalledAddOns which help users to know what a paclet is for